### PR TITLE
Add Extension Methods for Polyline and Vector3d

### DIFF
--- a/GeometryExtensions.sln
+++ b/GeometryExtensions.sln
@@ -13,8 +13,6 @@ Global
 		AutoCAD25_Release|x64 = AutoCAD25_Release|x64
 		BricsCAD_Debug|x64 = BricsCAD_Debug|x64
 		BricsCAD_Release|x64 = BricsCAD_Release|x64
-		Debug|x64 = Debug|x64
-		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.AutoCAD_Debug|x64.ActiveCfg = AutoCAD_Debug|x64
@@ -29,10 +27,6 @@ Global
 		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.BricsCAD_Debug|x64.Build.0 = BricsCAD_Debug|x64
 		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.BricsCAD_Release|x64.ActiveCfg = BricsCAD_Release|x64
 		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.BricsCAD_Release|x64.Build.0 = BricsCAD_Release|x64
-		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.Debug|x64.ActiveCfg = Debug|x64
-		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.Debug|x64.Build.0 = Debug|x64
-		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.Release|x64.ActiveCfg = Release|x64
-		{C2608FC8-352C-4615-9CB2-36CA728B20F8}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/GeometryExtensionsR25/GeometryExtensions.csproj
+++ b/GeometryExtensionsR25/GeometryExtensions.csproj
@@ -18,9 +18,6 @@
 		<Configurations>$(Configurations)AutoCAD_Release;AutoCAD25_Release;BricsCAD_Release;</Configurations>
 		<ImplicitUsings>enable</ImplicitUsings>
 	</PropertyGroup>
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-		<DocumentationFile>bin\Release\GeometryExtensions.XML</DocumentationFile>
-	</PropertyGroup>
 	<PropertyGroup Condition="$(Configuration.Contains('Debug'))">
 		<DebugSymbols>true</DebugSymbols>
 		<DefineConstants>TRACE;DEBUG;TA_BOTH_DLL</DefineConstants>
@@ -49,6 +46,7 @@
 		<TargetFramework>net48</TargetFramework>
 		<OutputPath>bin\AutoCAD_Release\</OutputPath>
 		<AssemblyName>GeometryExtensionR19</AssemblyName>
+		<DocumentationFile>bin\Release\GeometryExtensionR19.XML</DocumentationFile>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)' == 'AutoCAD25_Debug'">
@@ -62,6 +60,7 @@
 		<TargetFramework>net8.0-windows</TargetFramework>
 		<OutputPath>bin\AutoCAD_Release\</OutputPath>
 		<AssemblyName>GeometryExtensionR25</AssemblyName>
+		<DocumentationFile>bin\Release\GeometryExtensionR25.XML</DocumentationFile>
 		<DefineConstants>$(DefineConstants); ACAD_2025</DefineConstants>
 	</PropertyGroup>
 
@@ -75,6 +74,7 @@
 		<TargetFramework>net48</TargetFramework>
 		<OutputPath>bin\BricsCAD_Release\</OutputPath>
 		<AssemblyName>GeometryExtensionBrics</AssemblyName>
+		<DocumentationFile>bin\Release\GeometryExtensionBrics.XML</DocumentationFile>
 	</PropertyGroup>
 
 	<!--<ItemGroup Condition="$(Configuration.Contains('AutoCAD'))">

--- a/GeometryExtensionsR25/PolylineExtension.cs
+++ b/GeometryExtensionsR25/PolylineExtension.cs
@@ -375,5 +375,43 @@
         {
             return ((p2.X - p1.X) * (p3.Y - p1.Y) - (p2.Y - p1.Y) * (p3.X - p1.X)) < 1e-8;
         }
+
+        /// <summary>
+        /// Find the segment closest to the given point
+        /// </summary>
+        /// <param name="pline"></param>
+        /// <param name="point"></param>
+        /// <returns>the index of the segment closest to the given point. it actually returns
+        /// the index of the vertext before the segment</returns>
+        public static int SegmentIndexAt(this Polyline pline, Point3d point)
+        {
+            int closestVertex = 0;
+            try
+            {
+                Point3d closestPt = pline.GetClosestPointTo(point, false);
+                if (closestPt.DistanceTo(pline.EndPoint) > .001)
+                {
+                    return pline.NumberOfVertices - 1;
+                }
+                double pointDistance = pline.GetDistAtPoint(closestPt);
+                // iterate through the vertices
+                for (int i = 0; i < pline.NumberOfVertices - 1; i++)
+                {
+                    double vertexDistance = pline.GetDistanceAtParameter(i);
+                    if (vertexDistance < pointDistance)
+                    {
+                        // we haven't passed the point yet
+                        closestVertex = i;
+                    }
+                }
+            }
+            catch
+            {
+                // ignored, TODO: this exception should be handled properly by the caller instead of suppressing it 
+            }
+
+            return closestVertex;
+        }
+
     }
 }

--- a/GeometryExtensionsR25/Vector3dExtension.cs
+++ b/GeometryExtensionsR25/Vector3dExtension.cs
@@ -13,5 +13,28 @@ namespace Gile.AutoCAD.Geometry
         /// <param name="vector">The instance to which this method applies.</param>
         /// <returns>he projected vector.</returns>
         public static Vector3d Flatten(this Vector3d vector) => new(vector.X, vector.Y, 0.0);
+
+        /// <summary>
+        /// Returns the angle in rads from the x-axis that is used for the rotation of a block aligned with the vector
+        /// </summary>
+        /// <param name="vec"></param>
+        /// <returns></returns>
+        public static double RadsFromXAxis(this Vector3d vec)
+        {
+            var xAxis = new Vector3d(1, 0, 0);
+            return Math.Atan2(vec.Y - xAxis.Y, vec.X - xAxis.X);
+        }
+
+        /// <summary>
+        /// Returns the angle in degrees from the x-axis that is used for the rotation of a block aligned with the vector
+        /// </summary>
+        /// <param name="vec"></param>
+        /// <returns></returns>
+        public static double DegreesFromXAxis(this Vector3d vec)
+        {
+            var xAxis = new Vector3d(1, 0, 0);
+            var rads = Math.Atan2(vec.Y - xAxis.Y, vec.X - xAxis.X);
+            return rads * 180 / Math.PI;
+        }
     }
 }


### PR DESCRIPTION
This PR adds new extension methods for Polyline and Vector3d to enhance the functionality and reusability within Raindrop. These methods include custom operations frequently used in the project, ensuring cleaner and more maintainable code.