### PR TITLE
Introduce new Hatch extension method to calculate Area when Area property throws an exception

### DIFF
--- a/GeometryExtensionsR25/HatchExtension.cs
+++ b/GeometryExtensionsR25/HatchExtension.cs
@@ -113,5 +113,41 @@ namespace Gile.AutoCAD.Geometry
             }
             return result;
         }
+
+        /// <summary>
+        /// Gets the area of the specified hatch.
+        /// </summary>
+        /// <param name="hatch">The hatch instance to which this method applies.</param>
+        /// <returns>The area of the hatch.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if <paramref name="hatch"/> is null.</exception>
+        public static double GetHatchArea(this Hatch hatch)
+        {
+            if (hatch == null)
+            {
+                throw new ArgumentNullException(nameof(hatch));
+            }
+
+            try
+            {
+                return hatch.Area;
+            }
+            catch
+            {
+                // If hatch.Area fails, calculate the area manually
+                return CalculateHatchAreaManually(hatch);
+            }
+        }
+
+        /// <summary>
+        /// Calculates the area of the specified hatch manually by summing the areas of its boundary curves.
+        /// </summary>
+        /// <param name="hatch">The hatch instance to which this method applies.</param>
+        /// <returns>The manually calculated area of the hatch.</returns>
+        private static double CalculateHatchAreaManually(Hatch hatch)
+        {
+            var boundaries = hatch.GetBoundary();
+            return boundaries.Sum(curve => curve.Area);
+        }
+
     }
 }


### PR DESCRIPTION
This pull request introduces a new extension method for the `Hatch` class to calculate the area of a hatch manually when the normal `Area` property throws a "not applicable" exception. The method `GetHatchArea` first attempts to retrieve the area using the `hatch.Area` property and, if that fails, it falls back to a manual calculation by summing the areas of the boundary curves.

### Summary of Changes:
- Added `GetHatchArea` method to the `HatchExtensions` class.
- Implemented manual area calculation in `CalculateHatchAreaManually` method.

### Implementation Details:
- The `GetHatchArea` method first tries to use the `hatch.Area` property.
- If an exception is thrown, it calls the `CalculateHatchAreaManually` method.
- The `CalculateHatchAreaManually` method retrieves the boundary curves of the hatch and sums their areas.

### Potential Issues:
While this solution provides a fallback mechanism for calculating hatch areas, it is important to address the root cause of the issue. For example, the hatch might have been created using an API with a default loop type instead of `External`, as explained in [this thread](https://forums.autodesk.com/t5/net/getting-area-of-programmatically-created-hatch/td-p/5600158). Additionally, manually calculating the area may not be accurate in all cases, particularly for complex hatches with islands that cannot be detected correctly from hatch loops.

### Recommendations:
- Investigate the source of the hatch drafting issue.
- Verify if the hatch was created using the API with an incorrect loop type.
- Consider other potential geometry issues that might affect the area calculation.

This approach provides a temporary solution but identifying and fixing the root cause of the issue will ensure more accurate area calculations for hatches.